### PR TITLE
Settings: forward port lock pattern grid size (2/2)

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2021,6 +2021,8 @@
             android:exported="false"
             android:theme="@style/SetupWizardTheme.Light" />
 
+        <activity android:name="ChooseLockPatternSize" android:exported="false"/>
+
         <activity android:name="SetupChooseLockPassword"
             android:exported="false"
             android:taskAffinity="com.android.wizard"

--- a/res/layout/crypt_keeper_pattern_entry.xml
+++ b/res/layout/crypt_keeper_pattern_entry.xml
@@ -36,6 +36,18 @@
 
     </LinearLayout>
 
+    <LinearLayout
+            android:id="@+id/pattern_sizes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/crypt_keeper_pattern_margin"
+            android:layout_marginEnd="@dimen/crypt_keeper_pattern_margin"
+            android:orientation="horizontal">
+
+        <include layout="@layout/crypt_keeper_pattern_sizes" />
+
+    </LinearLayout>
+
     <include layout="@layout/crypt_keeper_emergency_button" />
 
 </LinearLayout>

--- a/res/layout/crypt_keeper_pattern_sizes.xml
+++ b/res/layout/crypt_keeper_pattern_sizes.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2015 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <Button
+            android:id="@+id/lock_pattern_size_3"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:textSize="14sp"
+            android:fontFamily="sans-serif"
+            android:text="@string/lock_pattern_size_3"
+            android:textColor="@color/text_color_white"
+            android:layout_weight="1"
+            style="?android:attr/borderlessButtonStyle"/>
+
+    <Button
+            android:id="@+id/lock_pattern_size_4"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:textSize="14sp"
+            android:fontFamily="sans-serif"
+            android:text="@string/lock_pattern_size_4"
+            android:textColor="@color/text_color_white"
+            android:layout_weight="1"
+            style="?android:attr/borderlessButtonStyle"/>
+
+    <Button
+            android:id="@+id/lock_pattern_size_5"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:textSize="14sp"
+            android:fontFamily="sans-serif"
+            android:text="@string/lock_pattern_size_5"
+            android:textColor="@color/text_color_white"
+            android:layout_weight="1"
+            style="?android:attr/borderlessButtonStyle"/>
+
+    <Button
+            android:id="@+id/lock_pattern_size_6"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:textSize="14sp"
+            android:fontFamily="sans-serif"
+            android:text="@string/lock_pattern_size_6"
+            android:textColor="@color/text_color_white"
+            android:layout_weight="1"
+            style="?android:attr/borderlessButtonStyle"/>
+
+
+</merge >
+

--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -309,6 +309,7 @@
     <!-- Sound settings, charging sounds label for ringtone == none -->
     <string name="power_notifications_ringtone_silent">Silent</string>
 
+
     <!-- Safe headset volume restore checkbox -->
     <string name="safe_headset_volume_title">Safe headset volume</string>
     <string name="safe_headset_volume_summary">Prevent loud volume levels when headset is first plugged in</string>
@@ -463,5 +464,17 @@
    <!-- Force authorize substratum packages -->
    <string name="force_authorize_substratum_packages_title">Force authorize every theme app</string>
    <string name="force_authorize_substratum_packages_summary">Allow theme apps from unknown sources</string>
+
+    <!-- Sizes for pattern lockscreen -->
+    <string name="lock_pattern_size_3">3x3</string>
+    <string name="lock_pattern_size_4">4x4</string>
+    <string name="lock_pattern_size_5">5x5</string>
+    <string name="lock_pattern_size_6">6x6</string>
+
+    <!-- Whether a visible red line will be drawn after the user has drawn the unlock pattern incorrectly -->
+    <string name="lockpattern_settings_enable_error_path_title">Show pattern error</string>
+    <!-- Whether the dots will be drawn when using the lockscreen pattern -->
+    <string name="lockpattern_settings_enable_dots_title">Show pattern dots</string>
+
 
 </resources>

--- a/res/xml/security_settings.xml
+++ b/res/xml/security_settings.xml
@@ -14,7 +14,8 @@
      limitations under the License.
 -->
 
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+<PreferenceScreen
+        xmlns:android="http://schemas.android.com/apk/res/android"
         android:title="@string/security_settings_title">
 
 </PreferenceScreen>

--- a/res/xml/security_settings_pattern_size.xml
+++ b/res/xml/security_settings_pattern_size.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2012-2013 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <PreferenceScreen
+        android:key="lock_pattern_size_3"
+        android:title="@string/lock_pattern_size_3"
+        android:persistent="false"/>
+
+    <PreferenceScreen
+        android:key="lock_pattern_size_4"
+        android:title="@string/lock_pattern_size_4"
+        android:persistent="false"/>
+
+    <PreferenceScreen
+        android:key="lock_pattern_size_5"
+        android:title="@string/lock_pattern_size_5"
+        android:persistent="false"/>
+
+    <PreferenceScreen
+        android:key="lock_pattern_size_6"
+        android:title="@string/lock_pattern_size_6"
+        android:persistent="false"/>
+
+</PreferenceScreen>

--- a/src/com/android/settings/ChooseLockPattern.java
+++ b/src/com/android/settings/ChooseLockPattern.java
@@ -75,7 +75,7 @@ public class ChooseLockPattern extends SettingsActivity {
 
     public static Intent createIntent(Context context,
             boolean requirePassword, boolean confirmCredentials, int userId) {
-        Intent intent = new Intent(context, ChooseLockPattern.class);
+        Intent intent = new Intent(context, ChooseLockPatternSize.class);
         intent.putExtra("key_lock_method", "pattern");
         intent.putExtra(ChooseLockGeneric.CONFIRM_CREDENTIALS, confirmCredentials);
         intent.putExtra(EncryptionInterstitial.EXTRA_REQUIRE_PASSWORD, requirePassword);
@@ -151,16 +151,12 @@ public class ChooseLockPattern extends SettingsActivity {
         protected List<LockPatternView.Cell> mChosenPattern = null;
         private boolean mHideDrawer = false;
 
+        private byte mPatternSize = LockPatternUtils.PATTERN_SIZE_DEFAULT;
+
         /**
          * The patten used during the help screen to show how to draw a pattern.
          */
-        private final List<LockPatternView.Cell> mAnimatePattern =
-                Collections.unmodifiableList(Lists.newArrayList(
-                        LockPatternView.Cell.of(0, 0),
-                        LockPatternView.Cell.of(0, 1),
-                        LockPatternView.Cell.of(1, 1),
-                        LockPatternView.Cell.of(2, 1)
-                ));
+        private List<LockPatternView.Cell> mAnimatePattern;
 
         @Override
         public void onActivityResult(int requestCode, int resultCode,
@@ -209,7 +205,13 @@ public class ChooseLockPattern extends SettingsActivity {
                     if (mUiStage == Stage.NeedToConfirm || mUiStage == Stage.ConfirmWrong) {
                         if (mChosenPattern == null) throw new IllegalStateException(
                                 "null chosen pattern in stage 'need to confirm");
-                        if (mChosenPattern.equals(pattern)) {
+
+                        final String chosenPatternStr = LockPatternUtils.patternToString(
+                                mChosenPattern, mPatternSize);
+                        final String potentialPatternStr = LockPatternUtils.patternToString(
+                                pattern, mPatternSize);
+
+                        if (chosenPatternStr.equals(potentialPatternStr)) {
                             updateStage(Stage.ChoiceConfirmed);
                         } else {
                             updateStage(Stage.ConfirmWrong);
@@ -386,7 +388,8 @@ public class ChooseLockPattern extends SettingsActivity {
                 w.setBlocking(true);
                 w.setListener(this);
                 w.start(mChooseLockSettingsHelper.utils(), required,
-                        false, 0, LockPatternUtils.stringToPattern(current), current, mUserId);
+                        false, 0, LockPatternUtils.stringToPattern(current, mPatternSize),
+                        current, mUserId, mPatternSize);
             }
             mHideDrawer = getActivity().getIntent().getBooleanExtra(EXTRA_HIDE_DRAWER, false);
         }
@@ -394,10 +397,17 @@ public class ChooseLockPattern extends SettingsActivity {
         @Override
         public View onCreateView(LayoutInflater inflater, ViewGroup container,
                 Bundle savedInstanceState) {
-            final GlifLayout layout = (GlifLayout) inflater.inflate(
-                    R.layout.choose_lock_pattern, container, false);
-            layout.setHeaderText(getActivity().getTitle());
-            return layout;
+            mPatternSize = getActivity().getIntent().getByteExtra("pattern_size",
+                    LockPatternUtils.PATTERN_SIZE_DEFAULT);
+            LockPatternView.Cell.updateSize(mPatternSize);
+            mAnimatePattern = Collections.unmodifiableList(Lists.newArrayList(
+                    LockPatternView.Cell.of(0, 0, mPatternSize),
+                    LockPatternView.Cell.of(0, 1, mPatternSize),
+                    LockPatternView.Cell.of(1, 1, mPatternSize),
+                    LockPatternView.Cell.of(2, 1, mPatternSize)
+                    ));
+
+            return inflater.inflate(R.layout.choose_lock_pattern, container, false);
         }
 
         @Override
@@ -408,6 +418,8 @@ public class ChooseLockPattern extends SettingsActivity {
             mLockPatternView.setOnPatternListener(mChooseNewLockPatternListener);
             mLockPatternView.setTactileFeedbackEnabled(
                     mChooseLockSettingsHelper.utils().isTactileFeedbackEnabled());
+            mLockPatternView.setLockPatternUtils(mChooseLockSettingsHelper.utils());
+            mLockPatternView.setLockPatternSize(mPatternSize);
 
             mFooterText = (TextView) view.findViewById(R.id.footerText);
 
@@ -452,7 +464,9 @@ public class ChooseLockPattern extends SettingsActivity {
                 // restore from previous state
                 final String patternString = savedInstanceState.getString(KEY_PATTERN_CHOICE);
                 if (patternString != null) {
-                    mChosenPattern = LockPatternUtils.stringToPattern(patternString);
+                    mChosenPattern = LockPatternUtils.stringToPattern(patternString,
+                            mPatternSize);
+                    mLockPatternView.setPattern(DisplayMode.Correct, mChosenPattern);
                 }
 
                 if (mCurrentPattern == null) {
@@ -555,7 +569,7 @@ public class ChooseLockPattern extends SettingsActivity {
             outState.putInt(KEY_UI_STAGE, mUiStage.ordinal());
             if (mChosenPattern != null) {
                 outState.putString(KEY_PATTERN_CHOICE,
-                        LockPatternUtils.patternToString(mChosenPattern));
+                        LockPatternUtils.patternToString(mChosenPattern, mPatternSize));
             }
 
             if (mCurrentPattern != null) {
@@ -672,7 +686,8 @@ public class ChooseLockPattern extends SettingsActivity {
             final boolean required = getActivity().getIntent().getBooleanExtra(
                     EncryptionInterstitial.EXTRA_REQUIRE_PASSWORD, true);
             mSaveAndFinishWorker.start(mChooseLockSettingsHelper.utils(), required,
-                    mHasChallenge, mChallenge, mChosenPattern, mCurrentPattern, mUserId);
+                    mHasChallenge, mChallenge, mChosenPattern, mCurrentPattern,
+                    mUserId, mPatternSize);
         }
 
         @Override
@@ -695,15 +710,18 @@ public class ChooseLockPattern extends SettingsActivity {
         private List<LockPatternView.Cell> mChosenPattern;
         private String mCurrentPattern;
         private boolean mLockVirgin;
+        private byte mPatternSize;
 
         public void start(LockPatternUtils utils, boolean credentialRequired,
                 boolean hasChallenge, long challenge,
-                List<LockPatternView.Cell> chosenPattern, String currentPattern, int userId) {
+                List<LockPatternView.Cell> chosenPattern, String currentPattern, int userId,
+                byte patternSize) {
             prepare(utils, credentialRequired, hasChallenge, challenge, userId);
 
             mCurrentPattern = currentPattern;
             mChosenPattern = chosenPattern;
             mUserId = userId;
+            mPatternSize = patternSize;
 
             mLockVirgin = !mUtils.isPatternEverChosen(mUserId);
 
@@ -714,6 +732,7 @@ public class ChooseLockPattern extends SettingsActivity {
         protected Intent saveAndVerifyInBackground() {
             Intent result = null;
             final int userId = mUserId;
+            mUtils.setLockPatternSize(mPatternSize, userId);
             mUtils.saveLockPattern(mChosenPattern, mCurrentPattern, userId);
 
             if (mHasChallenge) {

--- a/src/com/android/settings/ChooseLockPatternSize.java
+++ b/src/com/android/settings/ChooseLockPatternSize.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2012-2013 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.preference.PreferenceActivity;
+import android.support.v7.preference.Preference;
+import android.support.v7.preference.PreferenceScreen;
+
+import com.android.internal.widget.LockPatternUtils;
+
+import com.android.internal.logging.MetricsProto.MetricsEvent;
+
+public class ChooseLockPatternSize extends PreferenceActivity {
+
+    @Override
+    public Intent getIntent() {
+        Intent modIntent = new Intent(super.getIntent());
+        modIntent.putExtra(EXTRA_SHOW_FRAGMENT, ChooseLockPatternSizeFragment.class.getName());
+        modIntent.putExtra(EXTRA_NO_HEADERS, true);
+        return modIntent;
+    }
+
+    @Override
+    protected boolean isValidFragment(String fragmentName) {
+        if (ChooseLockPatternSizeFragment.class.getName().equals(fragmentName)) return true;
+        return false;
+    }
+
+    public static class ChooseLockPatternSizeFragment extends SettingsPreferenceFragment {
+        private ChooseLockSettingsHelper mChooseLockSettingsHelper;
+
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            mChooseLockSettingsHelper = new ChooseLockSettingsHelper(this.getActivity());
+            if (!(getActivity() instanceof ChooseLockPatternSize)) {
+                throw new SecurityException("Fragment contained in wrong activity");
+            }
+            addPreferencesFromResource(R.xml.security_settings_pattern_size);
+        }
+
+        @Override
+        public boolean onPreferenceTreeClick(Preference preference) {
+            final String key = preference.getKey();
+
+            byte patternSize;
+            if ("lock_pattern_size_4".equals(key)) {
+                patternSize = 4;
+            } else if ("lock_pattern_size_5".equals(key)) {
+                patternSize = 5;
+            } else if ("lock_pattern_size_6".equals(key)) {
+                patternSize = 6;
+            } else {
+                patternSize = 3;
+            }
+
+            final boolean isFallback = getActivity().getIntent()
+                .getBooleanExtra(LockPatternUtils.LOCKSCREEN_BIOMETRIC_WEAK_FALLBACK, false);
+
+            Intent intent = new Intent(getActivity(), ChooseLockPattern.class);
+            intent.putExtra("pattern_size", patternSize);
+            intent.putExtra("key_lock_method", "pattern");
+            intent.putExtra("confirm_credentials", false);
+            intent.putExtra(LockPatternUtils.LOCKSCREEN_BIOMETRIC_WEAK_FALLBACK,
+                    isFallback);
+
+            Intent originatingIntent = getActivity().getIntent();
+            // Forward the challenge extras if available in originating intent.
+            if (originatingIntent.hasExtra(ChooseLockSettingsHelper.EXTRA_KEY_HAS_CHALLENGE)) {
+                intent.putExtra(ChooseLockSettingsHelper.EXTRA_KEY_HAS_CHALLENGE,
+                        originatingIntent.getBooleanExtra(
+                                ChooseLockSettingsHelper.EXTRA_KEY_HAS_CHALLENGE, false));
+
+                intent.putExtra(ChooseLockSettingsHelper.EXTRA_KEY_CHALLENGE,
+                        originatingIntent.getLongExtra(
+                                ChooseLockSettingsHelper.EXTRA_KEY_CHALLENGE, 0));
+            }
+            // Forward the Encryption interstitial required password selection
+            if (originatingIntent.hasExtra(EncryptionInterstitial.EXTRA_REQUIRE_PASSWORD)) {
+                intent.putExtra(EncryptionInterstitial.EXTRA_REQUIRE_PASSWORD, originatingIntent
+                        .getBooleanExtra(EncryptionInterstitial.EXTRA_REQUIRE_PASSWORD, true));
+            }
+            intent.addFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT);
+            startActivity(intent);
+
+            finish();
+            return true;
+        }
+
+        @Override
+        protected int getMetricsCategory() {
+            return MetricsEvent.CUSTOM_SQUASH;
+        }
+    }
+}

--- a/src/com/android/settings/ConfirmLockPattern.java
+++ b/src/com/android/settings/ConfirmLockPattern.java
@@ -22,6 +22,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.os.SystemClock;
+import android.os.UserHandle;
 import android.os.UserManager;
 import android.os.storage.StorageManager;
 import android.view.LayoutInflater;
@@ -144,6 +145,7 @@ public class ConfirmLockPattern extends ConfirmDeviceCredentialBaseActivity {
                     mLockPatternUtils.isTactileFeedbackEnabled());
             mLockPatternView.setInStealthMode(!mLockPatternUtils.isVisiblePatternEnabled(
                     mEffectiveUserId));
+            mLockPatternView.setLockPatternSize(mLockPatternUtils.getLockPatternSize(mEffectiveUserId));
             mLockPatternView.setOnPatternListener(mConfirmExistingLockPatternListener);
             updateStage(Stage.NeedToUnlock);
 
@@ -479,7 +481,9 @@ public class ConfirmLockPattern extends ConfirmDeviceCredentialBaseActivity {
                                 mLockPatternUtils, pattern, challenge, localUserId,
                                 onVerifyCallback)
                         : LockPatternChecker.verifyTiedProfileChallenge(
-                                mLockPatternUtils, LockPatternUtils.patternToString(pattern),
+                                mLockPatternUtils,
+                                LockPatternUtils.patternToString(pattern,
+                                    mLockPatternUtils.getLockPatternSize(mEffectiveUserId)),
                                 true, challenge, localUserId, onVerifyCallback);
             }
 
@@ -504,7 +508,7 @@ public class ConfirmLockPattern extends ConfirmDeviceCredentialBaseActivity {
                                     intent.putExtra(ChooseLockSettingsHelper.EXTRA_KEY_TYPE,
                                                     StorageManager.CRYPT_TYPE_PATTERN);
                                     intent.putExtra(ChooseLockSettingsHelper.EXTRA_KEY_PASSWORD,
-                                                    LockPatternUtils.patternToString(pattern));
+                                                    mLockPatternUtils.patternToString(pattern, localEffectiveUserId));
                                 }
                                 mCredentialCheckResultTracker.setResult(matched, intent, timeoutMs,
                                         localEffectiveUserId);

--- a/src/com/android/settings/CryptKeeper.java
+++ b/src/com/android/settings/CryptKeeper.java
@@ -48,6 +48,8 @@ import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.view.View.OnClickListener;
 import android.view.View.OnKeyListener;
 import android.view.View.OnTouchListener;
@@ -67,6 +69,7 @@ import com.android.internal.widget.LockPatternView;
 import com.android.internal.widget.LockPatternView.Cell;
 import com.android.internal.widget.LockPatternView.DisplayMode;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -83,7 +86,7 @@ import java.util.List;
  * </pre>
  */
 public class CryptKeeper extends Activity implements TextView.OnEditorActionListener,
-        OnKeyListener, OnTouchListener, TextWatcher {
+        OnKeyListener, OnTouchListener, TextWatcher, OnClickListener {
     private static final String TAG = "CryptKeeper";
 
     private static final String DECRYPT_STATE = "trigger_restart_framework";
@@ -126,6 +129,15 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
     PowerManager.WakeLock mWakeLock;
     private EditText mPasswordEntry;
     private LockPatternView mLockPatternView;
+    private TextView mStatusText;
+    private List<Button> mLockPatternButtons = new ArrayList<>();
+    private static final int[] LOCK_BUTTON_IDS = new int[] {
+            R.id.lock_pattern_size_3,
+            R.id.lock_pattern_size_4,
+            R.id.lock_pattern_size_5,
+            R.id.lock_pattern_size_6
+    };
+
     /** Number of calls to {@link #notifyUser()} to ignore before notifying. */
     private int mNotificationCountdown = 0;
     /** Number of calls to {@link #notifyUser()} before we release the wakelock */
@@ -179,6 +191,9 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
+            if (mLockPatternView != null) {
+                mLockPatternView.removeCallbacks(mFakeUnlockAttemptRunnable);
+            }
             beginAttempt();
         }
 
@@ -202,13 +217,13 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
                     mLockPatternView.removeCallbacks(mClearPatternRunnable);
                     mLockPatternView.postDelayed(mClearPatternRunnable, RIGHT_PATTERN_CLEAR_TIMEOUT_MS);
                 }
-                final TextView status = (TextView) findViewById(R.id.status);
-                status.setText(R.string.starting_android);
+                mStatusText.setText(R.string.starting_android);
                 hide(R.id.passwordEntry);
                 hide(R.id.switch_ime_button);
                 hide(R.id.lockPattern);
                 hide(R.id.owner_info);
                 hide(R.id.emergencyCallButton);
+                hide(R.id.pattern_sizes);
             } else if (failedAttempts == MAX_FAILED_ATTEMPTS) {
                 // Factory reset the device.
                 if(mMdtpActivated){
@@ -240,8 +255,7 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
     }
 
     private void beginAttempt() {
-        final TextView status = (TextView) findViewById(R.id.status);
-        status.setText(R.string.checking_decryption);
+        mStatusText.setText(R.string.checking_decryption);
     }
 
     private void handleBadAttempt(Integer failedAttempts) {
@@ -257,14 +271,12 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
             // at this point.
             cooldown();
         } else {
-            final TextView status = (TextView) findViewById(R.id.status);
-
             int remainingAttempts = MAX_FAILED_ATTEMPTS - failedAttempts;
             if (remainingAttempts < COOL_DOWN_ATTEMPTS) {
                 CharSequence warningTemplate = getText(R.string.crypt_keeper_warn_wipe);
                 CharSequence warning = TextUtils.expandTemplate(warningTemplate,
                         Integer.toString(remainingAttempts));
-                status.setText(warning);
+                mStatusText.setText(warning);
             } else {
                 int passwordType = StorageManager.CRYPT_TYPE_PASSWORD;
                 try {
@@ -275,17 +287,18 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
                 }
 
                 if (passwordType == StorageManager.CRYPT_TYPE_PIN) {
-                    status.setText(R.string.cryptkeeper_wrong_pin);
+                    mStatusText.setText(R.string.cryptkeeper_wrong_pin);
                 } else if (passwordType == StorageManager.CRYPT_TYPE_PATTERN) {
-                    status.setText(R.string.cryptkeeper_wrong_pattern);
+                    mStatusText.setText(R.string.cryptkeeper_wrong_pattern);
                 } else {
-                    status.setText(R.string.cryptkeeper_wrong_password);
+                    mStatusText.setText(R.string.cryptkeeper_wrong_password);
                 }
             }
 
             if (mLockPatternView != null) {
                 mLockPatternView.setDisplayMode(DisplayMode.Wrong);
                 mLockPatternView.setEnabled(true);
+                setPatternButtonsEnabled(true);
             }
 
             // Reenable the password entry
@@ -418,6 +431,13 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        getWindow().getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION // hide nav bar
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN // hide status bar
+                        | View.SYSTEM_UI_FLAG_IMMERSIVE);
+
         // If we are not encrypted or encrypting, get out quickly.
         final String state = SystemProperties.get("vold.decrypt");
         final boolean isAlarmBoot = SystemProperties.getBoolean("ro.alarm_boot", false);
@@ -531,8 +551,7 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
                         setContentView(R.layout.crypt_keeper_password_entry);
                         mStatusString = R.string.enter_password;
                     }
-                    final TextView status = (TextView) findViewById(R.id.status);
-                    status.setText(mStatusString);
+                    mStatusText.setText(mStatusString);
 
                     final TextView ownerInfo = (TextView) findViewById(R.id.owner_info);
                     ownerInfo.setText(owner_info);
@@ -593,6 +612,12 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
             mWakeLock.release();
             mWakeLock = null;
         }
+    }
+
+    @Override
+    public void setContentView(int layoutResID) {
+        super.setContentView(layoutResID);
+        mStatusText = (TextView) findViewById(R.id.status);
     }
 
     /**
@@ -707,9 +732,8 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
             // Will happen if no time etc - show percentage
         }
 
-        final TextView tv = (TextView) findViewById(R.id.status);
-        if (tv != null) {
-            tv.setText(TextUtils.expandTemplate(status, progress));
+        if (mStatusText != null) {
+            mStatusText.setText(TextUtils.expandTemplate(status, progress));
         }
 
         // Check the progress every 1 seconds
@@ -725,12 +749,13 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
         if (mPasswordEntry != null) {
             mPasswordEntry.setEnabled(false);
         }
+
         if (mLockPatternView != null) {
             mLockPatternView.setEnabled(false);
+            setPatternButtonsEnabled(false);
         }
 
-        final TextView status = (TextView) findViewById(R.id.status);
-        status.setText(R.string.crypt_keeper_force_power_cycle);
+        mStatusText.setText(R.string.crypt_keeper_force_power_cycle);
     }
 
     /**
@@ -755,18 +780,21 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
 
         @Override
         public void onPatternStart() {
+            setPatternButtonsEnabled(false);
             mLockPatternView.removeCallbacks(mClearPatternRunnable);
         }
 
         @Override
         public void onPatternCleared() {
+            setPatternButtonsEnabled(true);
         }
 
         @Override
         public void onPatternDetected(List<LockPatternView.Cell> pattern) {
             mLockPatternView.setEnabled(false);
             if (pattern.size() >= MIN_LENGTH_BEFORE_REPORT) {
-                new DecryptTask().execute(LockPatternUtils.patternToString(pattern));
+                new DecryptTask().execute(LockPatternUtils.patternToString(pattern,
+                        mLockPatternView.getLockPatternSize()));
             } else {
                 // Allow user to make as many of these as they want.
                 fakeUnlockAttempt(mLockPatternView);
@@ -790,10 +818,18 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
             mPasswordEntry.addTextChangedListener(this);
         }
 
+         mLockPatternButtons.clear();
         // Pattern case
         mLockPatternView = (LockPatternView) findViewById(R.id.lockPattern);
         if (mLockPatternView != null) {
             mLockPatternView.setOnPatternListener(mChooseNewLockPatternListener);
+            for (int id : LOCK_BUTTON_IDS) {
+                Button btn = (Button) findViewById(id);
+                if (btn != null) {
+                    btn.setOnClickListener(this);
+                    mLockPatternButtons.add(btn);
+                }
+            }
         }
 
         // Disable the Emergency call button if the device has no voice telephone capability
@@ -1074,5 +1110,40 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
         Log.d(TAG, "Disabling component " + name);
         pm.setComponentEnabledSetting(name, PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
                 PackageManager.DONT_KILL_APP);
+    }
+
+    @Override
+    public void onClick(View v) {
+        if (mLockPatternView == null || !mLockPatternView.isEnabled()) {
+            return;
+        }
+        byte size;
+        switch (v.getId()) {
+            default:
+            case R.id.lock_pattern_size_3:
+                size = 3;
+                break;
+            case R.id.lock_pattern_size_4:
+                size = 4;
+                break;
+            case R.id.lock_pattern_size_5:
+                size = 5;
+                break;
+            case R.id.lock_pattern_size_6:
+                size = 6;
+                break;
+        }
+        setContentView(R.layout.crypt_keeper_pattern_entry);
+        passwordEntryInit();
+
+        mStatusText.setText(mStatusString = R.string.enter_pattern);
+        mLockPatternView.setLockPatternSize(size);
+        mLockPatternView.postInvalidate();
+    }
+
+    private void setPatternButtonsEnabled(boolean enabled) {
+        for (Button btn : mLockPatternButtons) {
+            btn.setEnabled(enabled);
+        }
     }
 }

--- a/src/com/android/settings/SecuritySettings.java
+++ b/src/com/android/settings/SecuritySettings.java
@@ -731,9 +731,11 @@ public class SecuritySettings extends SettingsPreferenceFragment
     private void unifyLocks() {
         int profileQuality =
                 mLockPatternUtils.getKeyguardStoredPasswordQuality(mProfileChallengeUserId);
+        final LockPatternUtils lockPatternUtils = mChooseLockSettingsHelper.utils();
         if (profileQuality == DevicePolicyManager.PASSWORD_QUALITY_SOMETHING) {
             mLockPatternUtils.saveLockPattern(
-                    LockPatternUtils.stringToPattern(mCurrentProfilePassword),
+                    LockPatternUtils.stringToPattern(mCurrentProfilePassword,
+                        lockPatternUtils.getLockPatternSize(MY_USER_ID)),
                     mCurrentDevicePassword, MY_USER_ID);
         } else {
             mLockPatternUtils.saveLockPassword(


### PR DESCRIPTION
Fingerprint: Forward challenge extras

The forward port of custom pattern sizes introduced a bug that would
cause an NPE when trying to add a fingerprint for security. This patch
forwards the extras associated with the challenge that would have
normally been passed directly in to the ChooseLockPattern fragment.

TICKET: CYNGNOS-1490

Settings: forward decrypt required on boot flag

This wasn't being pass forward and all of the defaults had it set to
true.

Ticket: CYNGNOS-2270
Signed-off-by: Roman Birg <roman@cyngn.com>

Settings: allow rotation while setting new pattern

Signed-off-by: Roman Birg <roman@cyngn.com>

Settings: use the actual user id to set pattern size

Ticket: CYNGNOS-2462

Settings: handle decrypting larger pattern sizes

Signed-off-by: Roman Birg <roman@cyngn.com>

CryptKeeper: pattern unlock displays incorrect pw when correct

fakeUnlockAttempt() gets called when the user inputs any pattern length
< 4 which queues up the 'incorrect error' message. The message needs to
be cleared before trying to actually check the password so it never goes
through in case the password was correct.

Signed-off-by: Roman Birg <roman@cyngn.com>

Settings: fix non lock pattern CryptKeeper crash

Signed-off-by: Roman Birg <roman@cyngn.com>

CryptKeeper: layout whole screen in bounds

Add flags to make the screen layout properly on devices with the
navigation bar visible

Signed-off-by: Roman Birg <roman@cyngn.com>

CryptKeeper improvements

- Status text was used enough to warrant it being a field variable
  instead of looking for the view every time

- Display proper text after changing pattern sizes (to input a pattern,
  not a password)

- Disable changing pattern sizes while validaing pattern

REFS: LETTUCE-557, LETTUCE-352
Signed-off-by: Roman Birg <roman@cyngn.com>
Signed-off-by: Shubham Singh <coolsks94@gmail.com>
Signed-off-by: Ayush Dubey <ayushdubey70@gmail.com>